### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyjvm/class_loader.py
+++ b/pyjvm/class_loader.py
@@ -315,7 +315,7 @@ def add_fields(jc, constant_pool, data):  # list of (flag, name, desc)
 
 
 def default_for_type(desc):
-    '''Default values for primiteves and refs'''
+    '''Default values for primitives and refs'''
     if desc == "I":
         return 0
     elif desc == "J":  # long

--- a/pyjvm/frame.py
+++ b/pyjvm/frame.py
@@ -22,7 +22,7 @@ f_counter = 1  # make it easy to debug
 
 
 class Frame(object):
-    '''Frame is created for every method invokation'''
+    '''Frame is created for every method invocation'''
 
     def __init__(self, _thread, _this_class, _method, _args=[], _desc=""):
         self.thread = _thread

--- a/pyjvm/ops/ops_invokeinterface.py
+++ b/pyjvm/ops/ops_invokeinterface.py
@@ -74,7 +74,7 @@ def invokeinterface(frame):
         vm_obj_call(frame, args, method_name, method_signature)
         return
 
-    # ignore signute polimorphic method
+    # ignore signature polymorphic method
     instance = frame.vm.heap[args[0][1]]
     klass = instance.java_class
     method = None

--- a/pyjvm/ops/ops_invokestatic.py
+++ b/pyjvm/ops/ops_invokestatic.py
@@ -45,7 +45,7 @@ def invokestatic(frame):
     assert method_signature is not None
 
     if klass_name == "sun/misc/VM" and method_name == "isBooted":
-        # shortcut, to be remvoed
+        # shortcut, to be removed
         frame.stack.append(1)
         return
 

--- a/pyjvm/ops/ops_invokevirtual.py
+++ b/pyjvm/ops/ops_invokevirtual.py
@@ -69,7 +69,7 @@ def invokevirtual(frame):
         vm_obj_call(frame, args, method_name, method_signature)
         return
 
-    # ignore signute polimorphic method
+    # ignore signature polymorphic method
     instance = frame.vm.heap[args[0][1]]
     klass = instance.java_class
     method = None

--- a/pyjvm/platform/java/lang/clazz.py
+++ b/pyjvm/platform/java/lang/clazz.py
@@ -19,7 +19,7 @@
 # NOT FULLY IMPLEMENTED!!!!
 # JUST ENOUGHT TO MAKE IT WORK
 #
-# Constructor paremeters always empty
+# Constructor parameters always empty
 #
 
 import logging

--- a/pyjvm/platform/sun/reflect/nativeconstructoraccessorimpl.py
+++ b/pyjvm/platform/sun/reflect/nativeconstructoraccessorimpl.py
@@ -36,7 +36,7 @@ def sun_reflect_NativeConstructorAccessorImpl_newInstance0__Ljava_lang_reflect_C
     frame.stack.append(iref)
     method = clazz.find_method("<init>", signature)
 
-    # actully running constructor in exclusive mode
+    # actually running constructor in exclusive mode
     pvm_thread = Thread(frame.vm, frame.vm.top_thread_ref)
     pvm_thread.is_alive = True
     m_args = [None]*method[1]

--- a/pyjvm/throw.py
+++ b/pyjvm/throw.py
@@ -17,7 +17,7 @@
 
 
 class JavaException(Exception):
-    '''PY excpetion.
+    '''PY exception.
 
     Real heap reference is stored in ref
     '''

--- a/pyjvm/utils.py
+++ b/pyjvm/utils.py
@@ -43,7 +43,7 @@ def args_count(desc):
 
 
 def _args_count(desc):
-    '''Recursive parsing for method signuture'''
+    '''Recursive parsing for method signature'''
     char_ = desc[0]
     if char_ == ")":
         return 0

--- a/pyjvm/vm.py
+++ b/pyjvm/vm.py
@@ -357,7 +357,7 @@ class VM(object):
         For each byte code specific operation function is called.
         Operation can throw exception.
         Thread may be busy (e.g. monitor is not available).
-        Returns from syncronized methods are handled.
+        Returns from synchronized methods are handled.
         '''
         frame_stack = thread.frame_stack
         while len(frame_stack) > 0:


### PR DESCRIPTION
There are small typos in:
- pyjvm/class_loader.py
- pyjvm/frame.py
- pyjvm/ops/ops_invokeinterface.py
- pyjvm/ops/ops_invokestatic.py
- pyjvm/ops/ops_invokevirtual.py
- pyjvm/platform/java/lang/clazz.py
- pyjvm/platform/sun/reflect/nativeconstructoraccessorimpl.py
- pyjvm/throw.py
- pyjvm/utils.py
- pyjvm/vm.py

Fixes:
- Should read `signature` rather than `signute`.
- Should read `polymorphic` rather than `polimorphic`.
- Should read `synchronized` rather than `syncronized`.
- Should read `signature` rather than `signuture`.
- Should read `removed` rather than `remvoed`.
- Should read `primitives` rather than `primiteves`.
- Should read `parameters` rather than `paremeters`.
- Should read `invocation` rather than `invokation`.
- Should read `exception` rather than `excpetion`.
- Should read `actually` rather than `actully`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md